### PR TITLE
10-change-application-usecontrol-data-type

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,13 +6,7 @@
   <component name="ChangeListManager">
     <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Rename from useVisibility.js to useControl.js">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_App.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_App.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_App.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_App.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useDragAndResize/useDraggableAppComponent.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useDragAndResize/useDraggableAppComponent.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/Desktop.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/Desktop.css" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/style/application.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/style/application.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -87,7 +81,7 @@
     "RunOnceActivity.ShowReadmeOnStart": "true",
     "RunOnceActivity.git.unshallow": "true",
     "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "9-maximize-function",
+    "git-widget-placeholder": "10-change-application-usecontrol-data-type",
     "ignore.virus.scanning.warn.message": "true",
     "last_opened_file_path": "C:/Users/Danny/Desktop/Personal Project/HTML_CSS_JS/Landing_Page/react_os_portfolio_style/public/Assets/Image/Icons",
     "list.type.of.created.stylesheet": "CSS",

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,13 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="update useControl.js and useSaveRect.js, fix the Maximize function">
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Chores: clean up useSaveRect.js debug line">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_App.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_App.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_App.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_App.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -505,7 +509,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751903308041</updated>
     </task>
-    <option name="localTasksCounter" value="40" />
+    <task id="LOCAL-00040" summary="Chores: clean up useSaveRect.js debug line">
+      <option name="closed" value="true" />
+      <created>1751903409870</created>
+      <option name="number" value="00040" />
+      <option name="presentableId" value="LOCAL-00040" />
+      <option name="project" value="LOCAL" />
+      <updated>1751903409870</updated>
+    </task>
+    <option name="localTasksCounter" value="41" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -535,7 +547,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="clean up code, updated README.md todo list and ideal list" />
     <MESSAGE value="more clean up code, more note on README.md and save work before the disaster :)" />
     <MESSAGE value="FIX: Draggable function now has limit to prevent user drag beyond the taskbar" />
     <MESSAGE value="Move `visibleClass` useState out of the App, change CSS class name with animation, improve resize event area" />
@@ -560,6 +571,7 @@
     <MESSAGE value="temporary remove debug line in useSaveRect.js, and update useControl.js" />
     <MESSAGE value="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function" />
     <MESSAGE value="update useControl.js and useSaveRect.js, fix the Maximize function" />
-    <option name="LAST_COMMIT_MESSAGE" value="update useControl.js and useSaveRect.js, fix the Maximize function" />
+    <MESSAGE value="Chores: clean up useSaveRect.js debug line" />
+    <option name="LAST_COMMIT_MESSAGE" value="Chores: clean up useSaveRect.js debug line" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,12 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Chores: reformat variable in _Wrapper.jsx and _App.jsx">
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Chores: clean up variable">
+      <change afterPath="$PROJECT_DIR$/src/hook/useWrapper/useWrapper.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useDragAndResize/useResizableAppComponent.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useDragAndResize/useResizableAppComponent.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -74,35 +76,35 @@
     <option name="showLibraryContents" value="true" />
     <option name="showScratchesAndConsoles" value="false" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "ASKED_SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "ModuleVcsDetector.initialDetectionPerformed": "true",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "SHARE_PROJECT_CONFIGURATION_FILES": "true",
-    "git-widget-placeholder": "10-change-application-usecontrol-data-type",
-    "ignore.virus.scanning.warn.message": "true",
-    "last_opened_file_path": "C:/Users/Danny/Desktop/Personal Project/HTML_CSS_JS/Landing_Page/react_os_portfolio_style/public/Assets/Image/Icons",
-    "list.type.of.created.stylesheet": "CSS",
-    "node.js.detected.package.eslint": "true",
-    "node.js.detected.package.tslint": "true",
-    "node.js.selected.package.eslint": "(autodetect)",
-    "node.js.selected.package.tslint": "(autodetect)",
-    "nodejs_interpreter_path": "node",
-    "nodejs_package_manager_path": "npm",
-    "npm.npm dev.executor": "Run",
-    "settings.editor.selected.configurable": "discord-application",
-    "ts.external.directory.path": "C:\\Program Files\\JetBrains\\WebStorm 2025.1\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external",
-    "vue.rearranger.settings.migration": "true"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;ASKED_SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;ModuleVcsDetector.initialDetectionPerformed&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;SHARE_PROJECT_CONFIGURATION_FILES&quot;: &quot;true&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;10-change-application-usecontrol-data-type&quot;,
+    &quot;ignore.virus.scanning.warn.message&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/Danny/Desktop/Personal Project/HTML_CSS_JS/Landing_Page/react_os_portfolio_style/public/Assets/Image/Icons&quot;,
+    &quot;list.type.of.created.stylesheet&quot;: &quot;CSS&quot;,
+    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
+    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
+    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
+    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
+    &quot;nodejs_interpreter_path&quot;: &quot;node&quot;,
+    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
+    &quot;npm.npm dev.executor&quot;: &quot;Run&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;discord-application&quot;,
+    &quot;ts.external.directory.path&quot;: &quot;C:\\Program Files\\JetBrains\\WebStorm 2025.1\\plugins\\javascript-plugin\\jsLanguageServicesImpl\\external&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
   },
-  "keyToStringList": {
-    "ChangesTree.GroupingKeys": [
-      "directory",
-      "repository"
+  &quot;keyToStringList&quot;: {
+    &quot;ChangesTree.GroupingKeys&quot;: [
+      &quot;directory&quot;,
+      &quot;repository&quot;
     ]
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\Users\Danny\Desktop\Personal Project\HTML_CSS_JS\Landing_Page\react_os_portfolio_style\public\Assets\Image\Icons" />
@@ -522,7 +524,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751904821487</updated>
     </task>
-    <option name="localTasksCounter" value="42" />
+    <task id="LOCAL-00042" summary="Chores: clean up variable">
+      <option name="closed" value="true" />
+      <created>1751908588462</created>
+      <option name="number" value="00042" />
+      <option name="presentableId" value="LOCAL-00042" />
+      <option name="project" value="LOCAL" />
+      <updated>1751908588462</updated>
+    </task>
+    <option name="localTasksCounter" value="43" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -552,7 +562,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="FIX: Draggable function now has limit to prevent user drag beyond the taskbar" />
     <MESSAGE value="Move `visibleClass` useState out of the App, change CSS class name with animation, improve resize event area" />
     <MESSAGE value="format README.md" />
     <MESSAGE value="FIX: Position is wrong when both app open" />
@@ -577,6 +586,7 @@
     <MESSAGE value="update useControl.js and useSaveRect.js, fix the Maximize function" />
     <MESSAGE value="Chores: clean up useSaveRect.js debug line" />
     <MESSAGE value="Chores: reformat variable in _Wrapper.jsx and _App.jsx" />
-    <option name="LAST_COMMIT_MESSAGE" value="Chores: reformat variable in _Wrapper.jsx and _App.jsx" />
+    <MESSAGE value="Chores: clean up variable" />
+    <option name="LAST_COMMIT_MESSAGE" value="Chores: clean up variable" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,13 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Chores: clean up useSaveRect.js debug line">
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Chores: reformat variable in _Wrapper.jsx and _App.jsx">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_App.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_App.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_App.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_App.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useDragAndResize/useResizableAppComponent.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useDragAndResize/useResizableAppComponent.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -517,7 +514,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751903409870</updated>
     </task>
-    <option name="localTasksCounter" value="41" />
+    <task id="LOCAL-00041" summary="Chores: reformat variable in _Wrapper.jsx and _App.jsx">
+      <option name="closed" value="true" />
+      <created>1751904821487</created>
+      <option name="number" value="00041" />
+      <option name="presentableId" value="LOCAL-00041" />
+      <option name="project" value="LOCAL" />
+      <updated>1751904821487</updated>
+    </task>
+    <option name="localTasksCounter" value="42" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -547,7 +552,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="more clean up code, more note on README.md and save work before the disaster :)" />
     <MESSAGE value="FIX: Draggable function now has limit to prevent user drag beyond the taskbar" />
     <MESSAGE value="Move `visibleClass` useState out of the App, change CSS class name with animation, improve resize event area" />
     <MESSAGE value="format README.md" />
@@ -572,6 +576,7 @@
     <MESSAGE value="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function" />
     <MESSAGE value="update useControl.js and useSaveRect.js, fix the Maximize function" />
     <MESSAGE value="Chores: clean up useSaveRect.js debug line" />
-    <option name="LAST_COMMIT_MESSAGE" value="Chores: clean up useSaveRect.js debug line" />
+    <MESSAGE value="Chores: reformat variable in _Wrapper.jsx and _App.jsx" />
+    <option name="LAST_COMMIT_MESSAGE" value="Chores: reformat variable in _Wrapper.jsx and _App.jsx" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,12 +4,10 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Chores: clean up variable">
-      <change afterPath="$PROJECT_DIR$/src/hook/useWrapper/useWrapper.js" afterDir="false" />
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="FIX: App can't drag and resize when user first open the application">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Contact/Contact_Wrapper.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" beforeDir="false" afterPath="$PROJECT_DIR$/src/component/Introduction/Introduction_Wrapper.jsx" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useDragAndResize/useResizableAppComponent.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useDragAndResize/useResizableAppComponent.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/style/application.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/style/application.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -532,7 +530,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751908588462</updated>
     </task>
-    <option name="localTasksCounter" value="43" />
+    <task id="LOCAL-00043" summary="FIX: App can't drag and resize when user first open the application">
+      <option name="closed" value="true" />
+      <created>1751909001324</created>
+      <option name="number" value="00043" />
+      <option name="presentableId" value="LOCAL-00043" />
+      <option name="project" value="LOCAL" />
+      <updated>1751909001324</updated>
+    </task>
+    <option name="localTasksCounter" value="44" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -562,7 +568,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Move `visibleClass` useState out of the App, change CSS class name with animation, improve resize event area" />
     <MESSAGE value="format README.md" />
     <MESSAGE value="FIX: Position is wrong when both app open" />
     <MESSAGE value="implement useFocus.js but still buggy, will fix it later" />
@@ -587,6 +592,7 @@
     <MESSAGE value="Chores: clean up useSaveRect.js debug line" />
     <MESSAGE value="Chores: reformat variable in _Wrapper.jsx and _App.jsx" />
     <MESSAGE value="Chores: clean up variable" />
-    <option name="LAST_COMMIT_MESSAGE" value="Chores: clean up variable" />
+    <MESSAGE value="FIX: App can't drag and resize when user first open the application" />
+    <option name="LAST_COMMIT_MESSAGE" value="FIX: App can't drag and resize when user first open the application" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,9 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function">
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="update useControl.js and useSaveRect.js, fix the Maximize function">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -498,7 +497,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751902471938</updated>
     </task>
-    <option name="localTasksCounter" value="39" />
+    <task id="LOCAL-00039" summary="update useControl.js and useSaveRect.js, fix the Maximize function">
+      <option name="closed" value="true" />
+      <created>1751903308041</created>
+      <option name="number" value="00039" />
+      <option name="presentableId" value="LOCAL-00039" />
+      <option name="project" value="LOCAL" />
+      <updated>1751903308041</updated>
+    </task>
+    <option name="localTasksCounter" value="40" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -528,7 +535,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Small update, add README.md" />
     <MESSAGE value="clean up code, updated README.md todo list and ideal list" />
     <MESSAGE value="more clean up code, more note on README.md and save work before the disaster :)" />
     <MESSAGE value="FIX: Draggable function now has limit to prevent user drag beyond the taskbar" />
@@ -553,6 +559,7 @@
     <MESSAGE value="move css animation app to separate animations.css" />
     <MESSAGE value="temporary remove debug line in useSaveRect.js, and update useControl.js" />
     <MESSAGE value="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function" />
-    <option name="LAST_COMMIT_MESSAGE" value="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function" />
+    <MESSAGE value="update useControl.js and useSaveRect.js, fix the Maximize function" />
+    <option name="LAST_COMMIT_MESSAGE" value="update useControl.js and useSaveRect.js, fix the Maximize function" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,8 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="move css animation app to separate animations.css">
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/style/animations.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/style/animations.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
@@ -475,7 +473,23 @@
       <option name="project" value="LOCAL" />
       <updated>1751901767814</updated>
     </task>
-    <option name="localTasksCounter" value="36" />
+    <task id="LOCAL-00036" summary="temporary remove debug line in useSaveRect.js, and update useControl.js">
+      <option name="closed" value="true" />
+      <created>1751902093265</created>
+      <option name="number" value="00036" />
+      <option name="presentableId" value="LOCAL-00036" />
+      <option name="project" value="LOCAL" />
+      <updated>1751902093265</updated>
+    </task>
+    <task id="LOCAL-00037" summary="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function">
+      <option name="closed" value="true" />
+      <created>1751902439822</created>
+      <option name="number" value="00037" />
+      <option name="presentableId" value="LOCAL-00037" />
+      <option name="project" value="LOCAL" />
+      <updated>1751902439822</updated>
+    </task>
+    <option name="localTasksCounter" value="38" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -505,8 +519,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="Change variable from elementRef to componentRef, for better consistence" />
-    <MESSAGE value="Save some work..." />
     <MESSAGE value="Small update, add README.md" />
     <MESSAGE value="clean up code, updated README.md todo list and ideal list" />
     <MESSAGE value="more clean up code, more note on README.md and save work before the disaster :)" />
@@ -530,6 +542,8 @@
     <MESSAGE value="update .gitignore" />
     <MESSAGE value="Rename from useVisibility.js to useControl.js" />
     <MESSAGE value="move css animation app to separate animations.css" />
-    <option name="LAST_COMMIT_MESSAGE" value="move css animation app to separate animations.css" />
+    <MESSAGE value="temporary remove debug line in useSaveRect.js, and update useControl.js" />
+    <MESSAGE value="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function" />
+    <option name="LAST_COMMIT_MESSAGE" value="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function" />
   </component>
 </project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,8 @@
   <component name="ChangeListManager">
     <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/style/animations.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/style/animations.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -489,7 +490,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751902439822</updated>
     </task>
-    <option name="localTasksCounter" value="38" />
+    <task id="LOCAL-00038" summary="remove visibleClass variable from Application and fix the css selector, but still got bug from useControl.js onClick_Maximize function">
+      <option name="closed" value="true" />
+      <created>1751902471938</created>
+      <option name="number" value="00038" />
+      <option name="presentableId" value="LOCAL-00038" />
+      <option name="project" value="LOCAL" />
+      <updated>1751902471938</updated>
+    </task>
+    <option name="localTasksCounter" value="39" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -4,10 +4,11 @@
     <option name="autoReloadType" value="SELECTIVE" />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="Rename from useVisibility.js to useControl.js">
+    <list default="true" id="d422f079-c637-4b48-9683-1960030fb594" name="Changes" comment="move css animation app to separate animations.css">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/Desktop.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/Desktop.css" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/style/application.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/style/application.css" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useControl/useControl.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useControl/useControl.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" beforeDir="false" afterPath="$PROJECT_DIR$/src/hook/useSaveRect/useSaveRect.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/style/animations.css" beforeDir="false" afterPath="$PROJECT_DIR$/src/style/animations.css" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -466,7 +467,15 @@
       <option name="project" value="LOCAL" />
       <updated>1751871721215</updated>
     </task>
-    <option name="localTasksCounter" value="35" />
+    <task id="LOCAL-00035" summary="move css animation app to separate animations.css">
+      <option name="closed" value="true" />
+      <created>1751901767814</created>
+      <option name="number" value="00035" />
+      <option name="presentableId" value="LOCAL-00035" />
+      <option name="project" value="LOCAL" />
+      <updated>1751901767814</updated>
+    </task>
+    <option name="localTasksCounter" value="36" />
     <servers />
   </component>
   <component name="TypeScriptGeneratedFilesManager">
@@ -496,7 +505,6 @@
     </option>
   </component>
   <component name="VcsManagerConfiguration">
-    <MESSAGE value="update createResizerDiv.js, now fix the resizer bug now app do have min-width and min-height base on CSS variable" />
     <MESSAGE value="Change variable from elementRef to componentRef, for better consistence" />
     <MESSAGE value="Save some work..." />
     <MESSAGE value="Small update, add README.md" />
@@ -521,6 +529,7 @@
     <MESSAGE value="Add RectGetter function to get the dimension and position of the component app" />
     <MESSAGE value="update .gitignore" />
     <MESSAGE value="Rename from useVisibility.js to useControl.js" />
-    <option name="LAST_COMMIT_MESSAGE" value="Rename from useVisibility.js to useControl.js" />
+    <MESSAGE value="move css animation app to separate animations.css" />
+    <option name="LAST_COMMIT_MESSAGE" value="move css animation app to separate animations.css" />
   </component>
 </project>

--- a/src/Desktop.css
+++ b/src/Desktop.css
@@ -3,6 +3,7 @@
 @import "style/reset.css";
 @import "style/application.css";
 @import "style/executable.css";
+@import "style/animations.css";
 
 :root {
     overflow: hidden;

--- a/src/component/Contact/Contact_App.jsx
+++ b/src/component/Contact/Contact_App.jsx
@@ -27,7 +27,7 @@ export const Contact_Executable = forwardRef(({onClick_Open}, iconRef) => {
 });
 
 export const Contact_App = forwardRef(
-    ({onClick_Close, onClick_Minimize, onClick_Maximize}, componentRef) => {
+    ({onClick_Close, onClick_Minimize, onClick_Maximize}, appRef) => {
     const Contact_Icon_Image = "./Assets/Image/Icons/Toast.png"
     const SVG_EMAIL = "./Assets/SVG/email.svg"
 
@@ -36,7 +36,7 @@ export const Contact_App = forwardRef(
         <div
             id="Global_App_Setting"
             className={`Contact_App`}
-            ref={componentRef}
+            ref={appRef}
         >
 
             {/* Title */}

--- a/src/component/Contact/Contact_App.jsx
+++ b/src/component/Contact/Contact_App.jsx
@@ -4,7 +4,6 @@ import {FiX} from "react-icons/fi";
 import {FaWindowMinimize} from "react-icons/fa6";
 import {MdFullscreen} from "react-icons/md";
 import "./Contact.css"
-import {useDragAndResize} from "../../hook/useDragAndResize/useDragAndResize.js";
 
 const APPLICATION_NAME = "Contact Me"
 
@@ -28,7 +27,7 @@ export const Contact_Executable = forwardRef(({onClick_Open}, iconRef) => {
 });
 
 export const Contact_App = forwardRef(
-    ({visibleClass, onClick_Close, onClick_Minimize, onClick_Maximize}, componentRef) => {
+    ({onClick_Close, onClick_Minimize, onClick_Maximize}, componentRef) => {
     const Contact_Icon_Image = "./Assets/Image/Icons/Toast.png"
     const SVG_EMAIL = "./Assets/SVG/email.svg"
 
@@ -36,7 +35,7 @@ export const Contact_App = forwardRef(
         // Contact Container
         <div
             id="Global_App_Setting"
-            className={`Contact_App ${visibleClass}`}
+            className={`Contact_App`}
             ref={componentRef}
         >
 

--- a/src/component/Contact/Contact_Wrapper.jsx
+++ b/src/component/Contact/Contact_Wrapper.jsx
@@ -8,7 +8,6 @@ export default function Contact_Wrapper() {
     const appRef = useRef(null)
     const iconRef = useRef(null)
     const {
-        visibleClass,
         isMounted,
         onClick_Open,
         onClick_Close,
@@ -29,7 +28,6 @@ export default function Contact_Wrapper() {
             {isMounted &&
                 <Contact_App
                     ref={appRef}
-                    visibleClass={visibleClass}
                     onClick_Close={onClick_Close}
                     onClick_Minimize={onClick_Minimize}
                     onClick_Maximize={onClick_Maximize}

--- a/src/component/Contact/Contact_Wrapper.jsx
+++ b/src/component/Contact/Contact_Wrapper.jsx
@@ -6,7 +6,6 @@ import {useDraggableIconComponent} from "../../hook/useDragAndResize/useDraggabl
 
 export default function Contact_Wrapper() {
     const appRef = useRef(null)
-    const iconRef = useRef(null)
     const {
         isMounted,
         onClick_Open,
@@ -14,7 +13,9 @@ export default function Contact_Wrapper() {
         onClick_Minimize,
         onClick_Maximize
     } = useControl(appRef);
-    const {componentState: appState} = useDragAndResize(appRef);
+    useDragAndResize(appRef);
+
+    const iconRef = useRef(null)
     useDraggableIconComponent(iconRef)
 
     return (

--- a/src/component/Contact/Contact_Wrapper.jsx
+++ b/src/component/Contact/Contact_Wrapper.jsx
@@ -1,22 +1,17 @@
-import React, {memo, useRef} from 'react'
+import React from 'react'
 import {Contact_App, Contact_Executable} from './Contact_App.jsx'
-import {useControl} from "../../hook/useControl/useControl.js";
-import {useDragAndResize} from "../../hook/useDragAndResize/useDragAndResize.js";
-import {useDraggableIconComponent} from "../../hook/useDragAndResize/useDraggableIconComponent.js";
+import {useWrapper} from "../../hook/useWrapper/useWrapper.js";
 
 export default function Contact_Wrapper() {
-    const appRef = useRef(null)
     const {
+        appRef,
+        iconRef,
         isMounted,
         onClick_Open,
         onClick_Close,
         onClick_Minimize,
-        onClick_Maximize
-    } = useControl(appRef);
-    useDragAndResize(appRef);
-
-    const iconRef = useRef(null)
-    useDraggableIconComponent(iconRef)
+        onClick_Maximize,
+    } = useWrapper();
 
     return (
         <>

--- a/src/component/Introduction/Introduction_App.jsx
+++ b/src/component/Introduction/Introduction_App.jsx
@@ -27,14 +27,14 @@ export const Introduction_Executable = forwardRef(({onClick_Open}, iconRef) => {
 });
 
 export const Introduction_App = forwardRef(
-    ({visibleClass, onClick_Close, onClick_Minimize, onClick_Maximize}, componentRef) => {
+    ({onClick_Close, onClick_Minimize, onClick_Maximize}, componentRef) => {
     const ProfilePicture = "./Assets/Image/Icons/Toast.png"
 
     return (
         // Introduction Container
         <div
             id="Global_App_Setting"
-            className={`Introduction_App ${visibleClass}`}
+            className={`Introduction_App`}
             ref={componentRef}
         >
 

--- a/src/component/Introduction/Introduction_App.jsx
+++ b/src/component/Introduction/Introduction_App.jsx
@@ -27,7 +27,7 @@ export const Introduction_Executable = forwardRef(({onClick_Open}, iconRef) => {
 });
 
 export const Introduction_App = forwardRef(
-    ({onClick_Close, onClick_Minimize, onClick_Maximize}, componentRef) => {
+    ({onClick_Close, onClick_Minimize, onClick_Maximize}, appRef) => {
     const ProfilePicture = "./Assets/Image/Icons/Toast.png"
 
     return (
@@ -35,7 +35,7 @@ export const Introduction_App = forwardRef(
         <div
             id="Global_App_Setting"
             className={`Introduction_App`}
-            ref={componentRef}
+            ref={appRef}
         >
 
             {/* Title */}

--- a/src/component/Introduction/Introduction_Wrapper.jsx
+++ b/src/component/Introduction/Introduction_Wrapper.jsx
@@ -9,7 +9,6 @@ export default function Introduction_Wrapper() {
     const appRef = useRef(null)
     const iconRef = useRef(null)
     const {
-        visibleClass,
         isMounted,
         onClick_Open,
         onClick_Close,
@@ -32,7 +31,6 @@ export default function Introduction_Wrapper() {
             {isMounted &&
                 <Introduction_App
                     ref={appRef}
-                    visibleClass={visibleClass}
                     onClick_Close={onClick_Close}
                     onClick_Minimize={onClick_Minimize}
                     onClick_Maximize={onClick_Maximize}

--- a/src/component/Introduction/Introduction_Wrapper.jsx
+++ b/src/component/Introduction/Introduction_Wrapper.jsx
@@ -1,25 +1,17 @@
-import React, {memo, useRef} from 'react'
+import React from 'react'
 import {Introduction_App, Introduction_Executable} from './Introduction_App.jsx'
-import {useControl} from "../../hook/useControl/useControl.js";
-import {useDragAndResize} from "../../hook/useDragAndResize/useDragAndResize.js";
-import {useDraggableAppComponent} from "../../hook/useDragAndResize/useDraggableAppComponent.js";
-import {useDraggableIconComponent} from "../../hook/useDragAndResize/useDraggableIconComponent.js";
+import {useWrapper} from "../../hook/useWrapper/useWrapper.js";
 
 export default function Introduction_Wrapper() {
-    const appRef = useRef(null)
     const {
+        appRef,
+        iconRef,
         isMounted,
         onClick_Open,
         onClick_Close,
         onClick_Minimize,
-        onClick_Maximize
-    } = useControl(appRef);
-    useDragAndResize(appRef);
-
-    const iconRef = useRef(null)
-    useDraggableIconComponent(iconRef)
-
-
+        onClick_Maximize,
+    } = useWrapper();
 
     return (
         <>

--- a/src/component/Introduction/Introduction_Wrapper.jsx
+++ b/src/component/Introduction/Introduction_Wrapper.jsx
@@ -7,7 +7,6 @@ import {useDraggableIconComponent} from "../../hook/useDragAndResize/useDraggabl
 
 export default function Introduction_Wrapper() {
     const appRef = useRef(null)
-    const iconRef = useRef(null)
     const {
         isMounted,
         onClick_Open,
@@ -15,7 +14,9 @@ export default function Introduction_Wrapper() {
         onClick_Minimize,
         onClick_Maximize
     } = useControl(appRef);
-    const {componentState: appState} = useDragAndResize(appRef);
+    useDragAndResize(appRef);
+
+    const iconRef = useRef(null)
     useDraggableIconComponent(iconRef)
 
 

--- a/src/hook/useControl/useControl.js
+++ b/src/hook/useControl/useControl.js
@@ -82,11 +82,11 @@ export function useControl(componentRef) {
         const component = componentRef.current;
         if (!component) return;
 
-        if (!component.classList.contains("MAXIMIZE")) {
+        if (!component.hasAttribute("app-control-state")) {
             const Taskbar = document.querySelector(`.Taskbar_Container`);
             const Taskbar_height = parseFloat(window.getComputedStyle(Taskbar).height) || 0
             setVisibleClass("MAXIMIZE")
-            component.setAttribute("app-control-status", "MAXIMIZE")
+            component.setAttribute("app-control-state", "MAXIMIZE")
 
             component.style.top = `0px`
             component.style.left = `0px`
@@ -95,7 +95,8 @@ export function useControl(componentRef) {
         } else {
             const {rectDimension} = RectGetter(componentRef)
             setVisibleClass("OPEN");
-            component.removeAttribute("app-control-status")
+            component.removeAttribute("app-control-state")
+            console.log(component)
 
             component.style.top = `${rectDimension.top}px`;
             component.style.left = `${rectDimension.left}px`;

--- a/src/hook/useControl/useControl.js
+++ b/src/hook/useControl/useControl.js
@@ -41,6 +41,7 @@ export function useControl(componentRef) {
 
             if (!component.classList.contains("OPEN")) {
                 setVisibleClass("OPEN")
+                component.setAttribute("app-control-status", "OPEN")
                 component.addEventListener("mousedown", onClick_Focus)
             }
             onClick_Focus()
@@ -54,6 +55,7 @@ export function useControl(componentRef) {
 
         if (!component.classList.contains("CLOSE")) {
             setVisibleClass("CLOSE")
+            component.setAttribute("app-control-status", "CLOSE")
             component.removeEventListener("mousedown", onClick_Focus)
             RectSetter(componentRef)
 
@@ -66,8 +68,9 @@ export function useControl(componentRef) {
         const component = componentRef.current;
         if (!component) return;
 
-        if (!component.classList.contains("HIDE")) {
-            setVisibleClass("HIDE")
+        if (!component.classList.contains("MINIMIZE")) {
+            setVisibleClass("MINIMIZE")
+            component.setAttribute("app-control-status", "MINIMIZE")
             component.removeEventListener("mousedown", onClick_Focus)
             RectSetter(componentRef)
         }
@@ -83,6 +86,7 @@ export function useControl(componentRef) {
             const Taskbar = document.querySelector(`.Taskbar_Container`);
             const Taskbar_height = parseFloat(window.getComputedStyle(Taskbar).height) || 0
             setVisibleClass("MAXIMIZE")
+            component.setAttribute("app-control-status", "MAXIMIZE")
 
             component.style.top = `0px`
             component.style.left = `0px`
@@ -91,6 +95,7 @@ export function useControl(componentRef) {
         } else {
             const {rectDimension} = RectGetter(componentRef)
             setVisibleClass("OPEN");
+            component.removeAttribute("app-control-status")
 
             component.style.top = `${rectDimension.top}px`;
             component.style.left = `${rectDimension.left}px`;

--- a/src/hook/useControl/useControl.js
+++ b/src/hook/useControl/useControl.js
@@ -105,5 +105,5 @@ export function useControl(componentRef) {
 
     }, [componentRef.current])
 
-    return {visibleClass, isMounted, onClick_Open, onClick_Close, onClick_Minimize, onClick_Maximize, onClick_Focus};
+    return {isMounted, onClick_Open, onClick_Close, onClick_Minimize, onClick_Maximize, onClick_Focus};
 }

--- a/src/hook/useDragAndResize/useDraggableAppComponent.js
+++ b/src/hook/useDragAndResize/useDraggableAppComponent.js
@@ -4,7 +4,7 @@ import {useControl} from "../useControl/useControl.js";
 
 export function useDraggableAppComponent(componentRef) {
     const [position, setPosition] = useState({x: 0, y: 0});
-    const {RectSetter, RectGetter} = useSaveRect()
+    const {RectSetter} = useSaveRect()
     const {onClick_Focus} = useControl(componentRef);
 
     useEffect(() => {

--- a/src/hook/useDragAndResize/useResizableAppComponent.js
+++ b/src/hook/useDragAndResize/useResizableAppComponent.js
@@ -61,9 +61,10 @@ export function useResizableAppComponent(componentRef) {
     function createResizerDiv(componentRef) {
         const directions = ['N', 'NE', 'E', 'SE', 'S', 'SW', 'W', 'NW'];
         const component = componentRef.current;
-        component.style.position = 'absolute'; // this is important, don't fucking touch it
 
         if (!component) return;
+
+        component.style.position = 'absolute'; // this is important, don't fucking touch it
 
         // Get min-width and min-height of the app
         const computedStyles = window.getComputedStyle(component);
@@ -215,7 +216,6 @@ export function useResizableAppComponent(componentRef) {
             const rectComponent = componentRef.current.getBoundingClientRect();
             const style = {
                 transform: 'translate(-50%, -50%)',  // Center the resizer
-                // background: 'red', // DEBUG
             };
 
             switch (dir) {

--- a/src/hook/useDragAndResize/useResizableAppComponent.js
+++ b/src/hook/useDragAndResize/useResizableAppComponent.js
@@ -4,7 +4,7 @@ import {useControl} from "../useControl/useControl.js";
 
 export function useResizableAppComponent(componentRef) {
     const [dimensions, setDimensions] = useState({width: 0, height: 0})
-    const {RectSetter, RectGetter} = useSaveRect()
+    const {RectSetter} = useSaveRect()
     const {onClick_Focus} = useControl(componentRef);
 
     useEffect(() => {

--- a/src/hook/useDragAndResize/useResizableAppComponent.js
+++ b/src/hook/useDragAndResize/useResizableAppComponent.js
@@ -83,29 +83,19 @@ export function useResizableAppComponent(componentRef) {
         existingResizer.forEach(resizer => resizer.remove());
 
         // Create Div base on directions arrays
-        const dirResizer = () => {
-            directions.forEach(dir => {
-                const resizer = document.createElement("div");
-                resizer.classList.add('resizer', `resizer_${dir}`);
-                Object.assign(resizer.style, {
-                    position: 'absolute',
-                    zIndex: 10,
-                    cursor: getCursor(dir),
-                    ...getPositionStyle(dir, componentRef),
-                });
-
-                resizer.addEventListener('mousedown', initResize(dir, component));
-                component.appendChild(resizer);
+        directions.forEach(dir => {
+            const resizer = document.createElement("div");
+            resizer.classList.add('resizer', `resizer_${dir}`);
+            Object.assign(resizer.style, {
+                position: 'absolute',
+                zIndex: 10,
+                cursor: getCursor(dir),
+                ...getPositionStyle(dir, componentRef),
             });
-        }
 
-        // HACK: Delay Resizer
-        if (component.classList.contains("OPEN")) {
-            setTimeout(() => dirResizer(), 110);
-        } else {
-            dirResizer()
-        }
-
+            resizer.addEventListener('mousedown', initResize(dir, component));
+            component.appendChild(resizer);
+        });
 
         // Create Resizer Logic
         function initResize(dir, component) {

--- a/src/hook/useSaveRect/useSaveRect.js
+++ b/src/hook/useSaveRect/useSaveRect.js
@@ -16,9 +16,9 @@ export function useSaveRect() {
         sessionStorage.setItem(appName, JSON.stringify(rectDimension))
 
         // DEBUG
-        console.group(`SET: ${appName}`)
-        console.log(rectDimension)
-        console.groupEnd()
+        // console.group(`SET: ${appName}`)
+        // console.log(rectDimension)
+        // console.groupEnd()
 
     }, [])
 
@@ -31,9 +31,9 @@ export function useSaveRect() {
         const rectDimension = JSON.parse(sessionStorage.getItem(appName))
 
         // DEBUG
-        console.group(`GET: ${appName}`)
-        console.log(rectDimension)
-        console.groupEnd()
+        // console.group(`GET: ${appName}`)
+        // console.log(rectDimension)
+        // console.groupEnd()
 
         return {rectDimension, appName}
     }, [])

--- a/src/hook/useSaveRect/useSaveRect.js
+++ b/src/hook/useSaveRect/useSaveRect.js
@@ -3,8 +3,8 @@ import {useCallback} from "react";
 export function useSaveRect() {
     // Set Rect of the component
     const RectSetter =  useCallback((componentRef) => {
-        if (!componentRef.current) return console.log("Invalid ComponentRef")
-        if (componentRef.current.classList.contains("MAXIMIZE")) return;
+        if (!componentRef.current) return;
+        if (componentRef.current.hasAttribute("app-control-state")) return;
 
         const component = componentRef.current;
         const appName = [...component.classList]

--- a/src/hook/useSaveRect/useSaveRect.js
+++ b/src/hook/useSaveRect/useSaveRect.js
@@ -15,11 +15,6 @@ export function useSaveRect() {
 
         sessionStorage.setItem(appName, JSON.stringify(rectDimension))
 
-        // DEBUG
-        // console.group(`SET: ${appName}`)
-        // console.log(rectDimension)
-        // console.groupEnd()
-
     }, [])
 
     const RectGetter = useCallback((componentRef) => {
@@ -29,11 +24,6 @@ export function useSaveRect() {
             .toString()
             .trim();
         const rectDimension = JSON.parse(sessionStorage.getItem(appName))
-
-        // DEBUG
-        // console.group(`GET: ${appName}`)
-        // console.log(rectDimension)
-        // console.groupEnd()
 
         return {rectDimension, appName}
     }, [])

--- a/src/hook/useWrapper/useWrapper.js
+++ b/src/hook/useWrapper/useWrapper.js
@@ -1,0 +1,38 @@
+// Create a new file: src/hook/useWrapper/useWrapper.js
+import { useRef, useCallback, useState } from 'react';
+import { useControl } from "../useControl/useControl.js";
+import { useDragAndResize } from "../useDragAndResize/useDragAndResize.js";
+import { useDraggableIconComponent } from "../useDragAndResize/useDraggableIconComponent.js";
+
+export function useWrapper() {
+    const appRef = useRef(null);
+    const iconRef = useRef(null)
+
+    // Get all control functionality
+    const {
+        isMounted,
+        onClick_Open,
+        onClick_Close,
+        onClick_Minimize,
+        onClick_Maximize,
+        onClick_Focus
+    } = useControl(appRef);
+
+    // Get drag and resize functionality
+    const { componentState } = useDragAndResize(appRef);
+
+    // Get drag for Icon
+    useDraggableIconComponent(iconRef)
+
+    return {
+        appRef,
+        iconRef,
+        isMounted,
+        onClick_Open,
+        onClick_Close,
+        onClick_Minimize,
+        onClick_Maximize,
+        onClick_Focus,
+        componentState
+    };
+}

--- a/src/style/animations.css
+++ b/src/style/animations.css
@@ -75,7 +75,7 @@
                 translate 100ms ease;
     }
 
-    &.HIDE {
+    &.MINIMIZE {
         opacity: 0;
         scale: 0.2;
         translate: 0 100%;

--- a/src/style/animations.css
+++ b/src/style/animations.css
@@ -3,7 +3,7 @@
     opacity: 0;
     transform-origin: bottom left;
 
-    &[data-app-control-status="OPEN"] {
+    &[app-control-status="OPEN"] {
         opacity: 1;
         scale: 1;
         translate: 0 0;
@@ -15,7 +15,7 @@
                 translate 100ms ease;
     }
 
-    &[data-app-control-status="CLOSE"] {
+    &[app-control-status="CLOSE"] {
         opacity: 0;
         scale: 0.2;
         translate: 0 0;
@@ -27,55 +27,7 @@
                 translate 100ms ease;
     }
 
-    &[data-app-control-status="MINIMIZE"] {
-        opacity: 0;
-        scale: 0.2;
-        translate: 0 100%;
-        pointer-events: none;
-
-        transition:
-                opacity 200ms ease,
-                scale 200ms ease,
-                translate 200ms ease ;
-    }
-
-    &[data-app-control-status="MAXIMIZE"] {
-        opacity: 1;
-        scale: 1;
-        translate: 0 0;
-        pointer-events: auto;
-
-        transition:
-                opacity 100ms ease,
-                scale 100ms ease,
-                translate 100ms ease;
-    }
-
-    &.OPEN {
-        opacity: 1;
-        scale: 1;
-        translate: 0 0;
-        pointer-events: auto;
-
-        transition:
-                opacity 100ms ease,
-                scale 100ms ease,
-                translate 100ms ease;
-    }
-
-    &.MAXIMIZE {
-        opacity: 1;
-        scale: 1;
-        translate: 0 0;
-        pointer-events: auto;
-
-        transition:
-                opacity 100ms ease,
-                scale 100ms ease,
-                translate 100ms ease;
-    }
-
-    &.MINIMIZE {
+    &[app-control-status="MINIMIZE"] {
         opacity: 0;
         scale: 0.2;
         translate: 0 100%;
@@ -87,9 +39,9 @@
                 translate 200ms ease ;
     }
 
-    &.CLOSE {
-        opacity: 0;
-        scale: 0.2;
+    &[app-control-status="MAXIMIZE"] {
+        opacity: 1;
+        scale: 1;
         translate: 0 0;
         pointer-events: auto;
 

--- a/src/style/animations.css
+++ b/src/style/animations.css
@@ -1,0 +1,101 @@
+#Global_App_Setting {
+    /* == Transition From Open, Close, Minimize and Maximize Action == */
+    opacity: 0;
+    transform-origin: bottom left;
+
+    &[data-app-control-status="OPEN"] {
+        opacity: 1;
+        scale: 1;
+        translate: 0 0;
+        pointer-events: auto;
+
+        transition:
+                opacity 100ms ease,
+                scale 100ms ease,
+                translate 100ms ease;
+    }
+
+    &[data-app-control-status="CLOSE"] {
+        opacity: 0;
+        scale: 0.2;
+        translate: 0 0;
+        pointer-events: auto;
+
+        transition:
+                opacity 100ms ease,
+                scale 100ms ease,
+                translate 100ms ease;
+    }
+
+    &[data-app-control-status="MINIMIZE"] {
+        opacity: 0;
+        scale: 0.2;
+        translate: 0 100%;
+        pointer-events: none;
+
+        transition:
+                opacity 200ms ease,
+                scale 200ms ease,
+                translate 200ms ease ;
+    }
+
+    &[data-app-control-status="MAXIMIZE"] {
+        opacity: 1;
+        scale: 1;
+        translate: 0 0;
+        pointer-events: auto;
+
+        transition:
+                opacity 100ms ease,
+                scale 100ms ease,
+                translate 100ms ease;
+    }
+
+    &.OPEN {
+        opacity: 1;
+        scale: 1;
+        translate: 0 0;
+        pointer-events: auto;
+
+        transition:
+                opacity 100ms ease,
+                scale 100ms ease,
+                translate 100ms ease;
+    }
+
+    &.MAXIMIZE {
+        opacity: 1;
+        scale: 1;
+        translate: 0 0;
+        pointer-events: auto;
+
+        transition:
+                opacity 100ms ease,
+                scale 100ms ease,
+                translate 100ms ease;
+    }
+
+    &.HIDE {
+        opacity: 0;
+        scale: 0.2;
+        translate: 0 100%;
+        pointer-events: none;
+
+        transition:
+                opacity 200ms ease,
+                scale 200ms ease,
+                translate 200ms ease ;
+    }
+
+    &.CLOSE {
+        opacity: 0;
+        scale: 0.2;
+        translate: 0 0;
+        pointer-events: auto;
+
+        transition:
+                opacity 100ms ease,
+                scale 100ms ease,
+                translate 100ms ease;
+    }
+}

--- a/src/style/application.css
+++ b/src/style/application.css
@@ -37,58 +37,6 @@
     display: flex;
     flex-direction: column;
 
-    /* == Transition From Open And Close Action == */
-    opacity: 0;
-    transform-origin: bottom left;
-
-    &.OPEN {
-        opacity: 1;
-        scale: 1;
-        translate: 0 0;
-        pointer-events: auto;
-
-        transition:
-                opacity 100ms ease,
-                scale 100ms ease,
-                translate 100ms ease;
-    }
-
-    &.MAXIMIZE {
-        opacity: 1;
-        scale: 1;
-        translate: 0 0;
-        pointer-events: auto;
-
-        transition:
-                opacity 100ms ease,
-                scale 100ms ease,
-                translate 100ms ease;
-    }
-
-    &.HIDE {
-        opacity: 0;
-        scale: 0.2;
-        translate: 0 100%;
-        pointer-events: none;
-
-        transition:
-                opacity 200ms ease,
-                scale 200ms ease,
-                translate 200ms ease ;
-    }
-
-    &.CLOSE {
-        opacity: 0;
-        scale: 0.2;
-        translate: 0 0;
-        pointer-events: auto;
-
-        transition:
-                opacity 100ms ease,
-                scale 100ms ease,
-                translate 100ms ease;
-    }
-
     /* == Resizer == */
     .resizer {
         transition: 100ms ease-in-out;


### PR DESCRIPTION
- Change `class` control to `data-id` type control.
- Fix the issue with the `can't drag or resize on the first app opened`
- Reformat and clean up CSS and JS
- Added useWrapper.js for centralize custom hook